### PR TITLE
修复在2023.1版本中getProjectFile() NPE 问题

### DIFF
--- a/src/main/java/com/bbc/plugins/utils/CommonUtil.java
+++ b/src/main/java/com/bbc/plugins/utils/CommonUtil.java
@@ -18,7 +18,7 @@ public class CommonUtil {
 
     public static PsiDirectory analysisPath(Project project, String module, String path) throws IOException {
         VirtualFile virtualFile = null;
-        for(VirtualFile file:project.getProjectFile().getParent().getParent().getChildren()){
+        for(VirtualFile file: Objects.requireNonNull(project.getProjectFile()).getParent().getParent().getChildren()){
             if(file.getName().contains(module)){
                 virtualFile = file;
             }


### PR DESCRIPTION
project.getProjectFile() 在 2023.1 版本中会有 null 情况，故此添加非空判断，解决生成 NPE 问题